### PR TITLE
add support for ts 3.8 type-only imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "import-sorter",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -40,9 +40,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.10.36",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.36.tgz",
-            "integrity": "sha512-SL6KhfM7PTqiFmbCW3eVNwVBZ+88Mrzbuvn9olPsfv43mbiWaFY+nRcz/TGGku0/lc2FepdMbImdMY1JrQ+zbw==",
+            "version": "14.14.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.13.tgz",
+            "integrity": "sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ==",
             "dev": true
         },
         "ajv": {
@@ -518,13 +518,12 @@
             "dev": true
         },
         "event-stream": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-            "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+            "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
             "dev": true,
             "requires": {
                 "duplexer": "^0.1.1",
-                "flatmap-stream": "^0.1.0",
                 "from": "^0.1.7",
                 "map-stream": "0.0.7",
                 "pause-stream": "^0.0.11",
@@ -639,12 +638,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
             "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
-        "flatmap-stream": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-            "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
             "dev": true
         },
         "for-in": {
@@ -2190,9 +2183,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+            "version": "3.9.7",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
         },
         "unique-stream": {
             "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "TypeScript Import Sorter",
   "description": "Extension sorts TypeScript imports according to the configuration provided. The configuration defaults follow ESLint sort-imports rule",
   "icon": "assets/icons/import-sorter.png",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "publisher": "mike-co",
   "engines": {
     "vscode": "^1.33.0"
@@ -43,20 +43,20 @@
   },
   "dependencies": {
     "glob": "^7.1.2",
-    "typescript": "^2.6.1",
     "lodash": "4.17.4",
-    "rxjs": "6.3.3"
+    "rxjs": "6.3.3",
+    "typescript": "^3.8.1"
   },
   "devDependencies": {
+    "@types/glob": "^5.0.30",
     "@types/lodash": "4.14.117",
     "@types/mocha": "^2.2.42",
-    "@types/node": "^8.10.25",
-    "@types/glob": "^5.0.30",
-    "vscode-nls": "^2.0.2",
+    "@types/node": "^14.14.13",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.3",
     "tslint": "^5.8.0",
-    "vscode": "^1.1.21"
+    "vscode": "^1.1.21",
+    "vscode-nls": "^2.0.2"
   },
   "contributes": {
     "commands": [

--- a/src/core/ast-parser.ts
+++ b/src/core/ast-parser.ts
@@ -127,19 +127,21 @@ export class SimpleImportAstParser implements AstParser {
         const moduleSpecifierName = importNode.importDeclaration.moduleSpecifier.kind === ts.SyntaxKind.StringLiteral
             ? (importNode.importDeclaration.moduleSpecifier as ts.StringLiteral).text
             : importNode.importDeclaration.moduleSpecifier.getFullText(sourceFile).trim();
+        const importClause = importNode.importDeclaration.importClause;
         const result: ImportElement = {
             moduleSpecifierName: moduleSpecifierName,
             startPosition: importNode.start,
             endPosition: importNode.end,
             hasFromKeyWord: false,
+            isTypeOnly: false,
             namedBindings: [],
             importComment: importNode.importComment
         };
 
-        const importClause = importNode.importDeclaration.importClause;
         if (!importClause) {
             return result;
         }
+        result.isTypeOnly = importClause.isTypeOnly;
         if (importClause.name) {
             result.hasFromKeyWord = true;
             result.defaultImportName = importClause.name.text;

--- a/src/core/import-creator.ts
+++ b/src/core/import-creator.ts
@@ -1,7 +1,8 @@
 import { chain, LoDashExplicitArrayWrapper } from 'lodash';
-
 import {
-    ImportElement, ImportElementGroup, ImportStringConfiguration
+  ImportElement,
+  ImportElementGroup,
+  ImportStringConfiguration,
 } from './models/models-public';
 
 export interface ImportCreator {
@@ -72,8 +73,9 @@ export class InMemoryImportCreator implements ImportCreator {
 
     private createSingleImportString(element: ImportElement) {
         const qMark = this.getQuoteMark();
+        const typeOnly = element.isTypeOnly ? 'type ' : '';
         if (!element.hasFromKeyWord) {
-            return `import ${qMark}${element.moduleSpecifierName}${qMark}${this.semicolonChar}`;
+            return `import ${typeOnly}${qMark}${element.moduleSpecifierName}${qMark}${this.semicolonChar}`;
         }
 
         if (element.namedBindings && element.namedBindings.length > 0) {
@@ -89,26 +91,27 @@ export class InMemoryImportCreator implements ImportCreator {
             );
         }
         if (element.defaultImportName) {
-            return `import ${element.defaultImportName} from ${qMark}${element.moduleSpecifierName}${qMark}${
+            return `import ${typeOnly}${element.defaultImportName} from ${qMark}${element.moduleSpecifierName}${qMark}${
                 this.semicolonChar
                 }`;
         } else {
-            return `import {} from ${qMark}${element.moduleSpecifierName}${qMark}${this.semicolonChar}`;
+            return `import ${typeOnly}{} from ${qMark}${element.moduleSpecifierName}${qMark}${this.semicolonChar}`;
         }
     }
 
     private createStarImport(element: ImportElement) {
         const qMark = this.getQuoteMark();
         const spaceConfig = this.getSpaceConfig();
+        const typeOnly = element.isTypeOnly ? 'type ' : '';
         if (element.defaultImportName) {
             // tslint:disable-next-line:max-line-length
-            return `import ${element.defaultImportName}${spaceConfig.beforeComma},${spaceConfig.afterComma}${
+            return `import ${typeOnly}${element.defaultImportName}${spaceConfig.beforeComma},${spaceConfig.afterComma}${
                 element.namedBindings[0].name
                 } as ${element.namedBindings[0].aliasName} from ${qMark}${element.moduleSpecifierName}${qMark}${
                 this.semicolonChar
                 }`;
         } else {
-            return `import ${element.namedBindings[0].name} as ${element.namedBindings[0].aliasName} from ${qMark}${
+            return `import ${typeOnly}${element.namedBindings[0].name} as ${element.namedBindings[0].aliasName} from ${qMark}${
                 element.moduleSpecifierName
                 }${qMark}${this.semicolonChar}`;
         }
@@ -264,16 +267,17 @@ export class InMemoryImportCreator implements ImportCreator {
     private createImportWithCurlyBracket(element: ImportElement, namedBindingString: string, isSingleLine: boolean) {
         const qMark = this.getQuoteMark();
         const spaceConfig = this.getSpaceConfig();
+        const typeOnly = element.isTypeOnly ? 'type ' : '';
         if (element.defaultImportName) {
             return isSingleLine
                 ? // tslint:disable-next-line:max-line-length
-                `import ${element.defaultImportName}${spaceConfig.beforeComma},${spaceConfig.afterComma}{${
+                `import ${typeOnly}${element.defaultImportName}${spaceConfig.beforeComma},${spaceConfig.afterComma}{${
                 spaceConfig.afterStartingBracket
                 }${namedBindingString}${spaceConfig.beforeEndingBracket}} from ${qMark}${
                 element.moduleSpecifierName
                 }${qMark}${this.semicolonChar}`
                 : // tslint:disable-next-line:max-line-length
-                `import ${element.defaultImportName}${spaceConfig.beforeComma},${
+                `import ${typeOnly}${element.defaultImportName}${spaceConfig.beforeComma},${
                 spaceConfig.afterComma
                 }{\n${namedBindingString}\n} from ${qMark}${element.moduleSpecifierName}${qMark}${
                 this.semicolonChar
@@ -281,10 +285,10 @@ export class InMemoryImportCreator implements ImportCreator {
         }
         return isSingleLine
             ? // tslint:disable-next-line:max-line-length
-            `import {${spaceConfig.afterStartingBracket}${namedBindingString}${
+            `import ${typeOnly}{${spaceConfig.afterStartingBracket}${namedBindingString}${
             spaceConfig.beforeEndingBracket
             }} from ${qMark}${element.moduleSpecifierName}${qMark}${this.semicolonChar}`
-            : `import {\n${namedBindingString}\n} from ${qMark}${element.moduleSpecifierName}${qMark}${
+            : `import ${typeOnly}{\n${namedBindingString}\n} from ${qMark}${element.moduleSpecifierName}${qMark}${
             this.semicolonChar
             }`;
     }

--- a/src/core/models/import-element.ts
+++ b/src/core/models/import-element.ts
@@ -5,6 +5,7 @@ export interface ImportElement {
     startPosition: { line: number; character: number };
     endPosition: { line: number; character: number };
     hasFromKeyWord: boolean;
+    isTypeOnly: boolean;
     defaultImportName?: string;
     namedBindings?: {
         aliasName: string;

--- a/test/ast-walker.test.ts
+++ b/test/ast-walker.test.ts
@@ -1,6 +1,5 @@
 import * as expect from 'expect.js';
 import 'mocha';
-
 import { SimpleImportAstParser } from '../src/core/ast-parser';
 import { ImportElement } from '../src/core/core-public';
 
@@ -20,6 +19,7 @@ suite('AstWalker tests', () => {
                 endPosition: { line: 0, character: 40 },
                 moduleSpecifierName: 'test.js',
                 hasFromKeyWord: true,
+                isTypeOnly: false,
                 namedBindings: [
                     { name: 'a', aliasName: null },
                     { name: 'c', aliasName: 'cc' },
@@ -46,6 +46,7 @@ suite('AstWalker tests', () => {
                 startPosition: { line: 1, character: 12 },
                 endPosition: { line: 4, character: 31 },
                 hasFromKeyWord: true,
+                isTypeOnly: false,
                 namedBindings: [
                     { name: 'a', aliasName: null },
                     { name: 'c', aliasName: 'cc' },
@@ -73,6 +74,7 @@ suite('AstWalker tests', () => {
                 endPosition: { line: 0, character: 39 },
                 moduleSpecifierName: 'test.js',
                 hasFromKeyWord: true,
+                isTypeOnly: false,
                 namedBindings: [
                     { name: 'a', aliasName: null },
                     { name: 'c', aliasName: 'cc' },
@@ -100,6 +102,7 @@ suite('AstWalker tests', () => {
                 startPosition: { line: 2, character: 12 },
                 endPosition: { line: 5, character: 31 },
                 hasFromKeyWord: true,
+                isTypeOnly: false,
                 namedBindings: [
                     { name: 'a', aliasName: null },
                     { name: 'c', aliasName: 'cc' },
@@ -131,7 +134,26 @@ suite('AstWalker tests', () => {
                     ]
                 }
             }
-        }
+        },
+        {
+            testName: 'test1e',
+            text: `import type { a, b } from "test.js"`,
+            expected: {
+                endPosition: { line: 0, character: 35 },
+                moduleSpecifierName: 'test.js',
+                hasFromKeyWord: true,
+                isTypeOnly: true,
+                namedBindings: [
+                    { name: 'a', aliasName: null },
+                    { name: 'b', aliasName: null }
+                ],
+                startPosition: { line: 0, character: 0 },
+                importComment: {
+                    leadingComments: [],
+                    trailingComments: []
+                }
+            }
+        },
     ];
 
     const getImports = (text: string) => {

--- a/test/import-creator.test.ts
+++ b/test/import-creator.test.ts
@@ -1,11 +1,10 @@
 import * as expect from 'expect.js';
 import 'mocha';
-
 import {
-    defaultImportStringConfiguration,
-    InMemoryImportCreator,
-    ImportElementGroup,
-    ImportStringConfiguration
+  defaultImportStringConfiguration,
+  ImportElementGroup,
+  ImportStringConfiguration,
+  InMemoryImportCreator,
 } from '../src/core/core-public';
 
 interface ImportCreatorTest {
@@ -37,6 +36,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 53 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             defaultImportName: 't',
                             namedBindings: [
                                 { name: 'B', aliasName: null },
@@ -71,6 +71,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 70 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'ChangeDetectionStrategy', aliasName: null },
                                 { name: 'DebugElement', aliasName: null }
@@ -103,6 +104,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 70 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'ChangeDetectionStrategy', aliasName: null },
                                 { name: 'DebugElement', aliasName: null }
@@ -135,6 +137,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 70 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'ChangeDetectionStrategy', aliasName: null },
                                 { name: 'DebugElement', aliasName: null }
@@ -167,6 +170,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 70 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'ChangeDetectionStrategy', aliasName: null },
                                 { name: 'DebugElement', aliasName: null }
@@ -199,6 +203,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 70 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'ChangeDetectionStrategy', aliasName: null },
                                 { name: 'DebugElement', aliasName: null }
@@ -231,6 +236,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 70 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'ChangeDetectionStrategy', aliasName: null },
                                 { name: 'DebugElement', aliasName: null }
@@ -263,6 +269,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 70 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'ChangeDetectionStrategy', aliasName: null },
                                 { name: 'DebugElement', aliasName: null }
@@ -295,6 +302,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 69 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'ChangeDetectionStrategy', aliasName: null },
                                 { name: 'DebugElement', aliasName: null }
@@ -327,6 +335,7 @@ suite('Import Creator Tests', () => {
                             startPosition: { line: 0, character: 0 },
                             endPosition: { line: 0, character: 40 },
                             hasFromKeyWord: true,
+                            isTypeOnly: false,
                             namedBindings: [
                                 { name: 'a', aliasName: null },
                                 { name: 'b', aliasName: null },
@@ -342,7 +351,34 @@ suite('Import Creator Tests', () => {
                 }
             ],
             expected: "import {\n    a, b,\n    c\n} from \'@angular/core\';"
-        }
+        },
+        {
+          testName: 'test10 - import string is type only',
+          config: createConfiguration({} as ImportStringConfiguration),
+          elementGroups: [
+              {
+                  elements: [
+                      {
+                          moduleSpecifierName: 'foo',
+                          startPosition: { line: 0, character: 0 },
+                          endPosition: { line: 0, character: 40 },
+                          hasFromKeyWord: true,
+                          isTypeOnly: true,
+                          namedBindings: [
+                              { name: 'a', aliasName: null },
+                              { name: 'b', aliasName: null },
+                          ],
+                          importComment: {
+                              leadingComments: [],
+                              trailingComments: []
+                          }
+                      }],
+                  numberOfEmptyLinesAfterGroup: 0,
+                  customOrderRule: null
+              }
+          ],
+          expected: "import type { a, b } from \'foo\';"
+      }
     ];
 
     const getImportText = (groups: ImportElementGroup[], config: ImportStringConfiguration) => {


### PR DESCRIPTION
Merging PR from original repo that fixes `import type`: https://github.com/SoominHan/import-sorter/pull/70